### PR TITLE
Serious flaw in the way Scrypt's output is protected

### DIFF
--- a/crypto/derivation.go
+++ b/crypto/derivation.go
@@ -16,15 +16,15 @@ func DeriveSecureValues(masterPassword, identifier []byte, costFactor map[string
 	copy(concatenatedValues[:len(masterPassword)], masterPassword)
 	copy(concatenatedValues[len(masterPassword):], identifier)
 
-	// Allocate and protect memory for the output of the hash function, and put the output into it.
-	rootKeySlice := memory.MakeProtected(64)
-	rootKeySlice, _ = scrypt.Key(
+	// Derive the rootKey and then protect it.
+	rootKeySlice, _ := scrypt.Key(
 		concatenatedValues,       // Input data.
 		[]byte(""),               // Salt.
 		1<<uint(costFactor["N"]), // Scrypt parameter N.
 		costFactor["r"],          // Scrypt parameter r.
 		costFactor["p"],          // Scrypt parameter p.
 		64)                       // Output hash length.
+	memory.Protect(rootKeySlice)
 
 	// Force the Go GC to do its job.
 	debug.FreeOSMemory()


### PR DESCRIPTION
If we consider the following code (available on the playground [here](https://play.golang.org/p/B0p_BSURnH)):

```
b := make([]byte, 4)
fmt.Println(&b[0]) // 0x1040a124
b = []byte("test")
fmt.Println(&b[0]) // 0x1040a128
	
c := make([]byte, 4)
fmt.Println(&c[0])
copy(c, []byte("test")) // 0x1040a140
fmt.Println(&c[0])      // 0x1040a140

```

As you can see, in the first case when we do a straight allocation, the address changes. Copy is hugely preferable as it keeps the address the same.

The patch however entails calling `memory.Protect()` after we allocate it. This is maybe not the best option but I don't see an alternative.

It may not matter since the kernel can only lock memory in full pages, which are each about 4kB on Linux.